### PR TITLE
Including usage/support for various new things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,23 @@ matrix:
     - os: osx
     - python: 3.7-dev
     - python: pypy3.3-5.2-alpha1
-    - env: TRAVIS_NODE_VERSION=7
+    - env: TRAVIS_NODE_VERSION=9
   include:
     - language: python
       python: 2.7
       env:
-        - TRAVIS_NODE_VERSION=0.12
+        - TRAVIS_NODE_VERSION=6.12
         - BROWSER=PhantomJS
     - language: python
       python: 3.3
       env:
-        - TRAVIS_NODE_VERSION=4.6
+        - TRAVIS_NODE_VERSION=6.12
         - BROWSER=Firefox
     - language: python
       dist: trusty
       python: 3.4
       env:
-        - TRAVIS_NODE_VERSION=4.6
+        - TRAVIS_NODE_VERSION=6.12
         - BROWSER=Chrome
       addons:
         apt:
@@ -31,28 +31,28 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - TRAVIS_NODE_VERSION=6.9
+        - TRAVIS_NODE_VERSION=6.12
         - BROWSER=PhantomJS
     - language: python
       python: 3.6
       env:
-        - TRAVIS_NODE_VERSION=7
+        - TRAVIS_NODE_VERSION=8.9
         - BROWSER=PhantomJS
     - language: python
       python: 3.7-dev
       env:
-        - TRAVIS_NODE_VERSION=7
+        - TRAVIS_NODE_VERSION=9
         - BROWSER=PhantomJS
     - language: python
       python: pypy
       env:
-        - TRAVIS_NODE_VERSION=0.12
+        - TRAVIS_NODE_VERSION=6.12
         - BROWSER=Firefox
     - language: python
       dist: trusty
-      python: pypy3.3-5.2-alpha1
+      python: pypy3
       env:
-        - TRAVIS_NODE_VERSION=6.9
+        - TRAVIS_NODE_VERSION=8.9
         - BROWSER=Chrome
       addons:
         apt:
@@ -62,19 +62,19 @@ matrix:
             - google-chrome-stable
     # test different versions of Node.js on osx
     - language: node_js
-      node_js: 4.6
+      node_js: 6.12
       os: osx
       env:
         - TRAVIS_PYTHON_VERSION=3.4.5
         - BROWSER=PhantomJS
     - language: node_js
-      node_js: 6.9
+      node_js: 8.9
       os: osx
       env:
         - TRAVIS_PYTHON_VERSION=3.5.3
         - BROWSER=Safari
     - language: node_js
-      node_js: 7.4
+      node_js: 9
       os: osx
       env:
         - TRAVIS_PYTHON_VERSION=3.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,19 @@ sudo: false
 matrix:
   allow_failures:
     - os: osx
-    - python: 3.7-dev
-    - python: pypy3.3-5.2-alpha1
-    - env: TRAVIS_NODE_VERSION=9
+    - python: 3.8-dev
+    - env: TRAVIS_NODE_VERSION=12
   include:
     - language: python
       python: 2.7
       env:
-        - TRAVIS_NODE_VERSION=6.12
+        - TRAVIS_NODE_VERSION=10
         - BROWSER=PhantomJS
-    - language: python
-      python: 3.3
-      env:
-        - TRAVIS_NODE_VERSION=6.12
-        - BROWSER=Firefox
     - language: python
       dist: trusty
       python: 3.4
       env:
-        - TRAVIS_NODE_VERSION=6.12
+        - TRAVIS_NODE_VERSION=8
         - BROWSER=Chrome
       addons:
         apt:
@@ -31,28 +25,37 @@ matrix:
     - language: python
       python: 3.5
       env:
-        - TRAVIS_NODE_VERSION=6.12
+        - TRAVIS_NODE_VERSION=10
         - BROWSER=PhantomJS
     - language: python
       python: 3.6
       env:
-        - TRAVIS_NODE_VERSION=8.9
+        - TRAVIS_NODE_VERSION=10
         - BROWSER=PhantomJS
     - language: python
-      python: 3.7-dev
+      python: 3.7
+      sudo: true
+      dist: xenial
       env:
-        - TRAVIS_NODE_VERSION=9
+        - TRAVIS_NODE_VERSION=10
+        - BROWSER=PhantomJS
+    - language: python
+      python: 3.8-dev
+      sudo: true
+      dist: xenial
+      env:
+        - TRAVIS_NODE_VERSION=12
         - BROWSER=PhantomJS
     - language: python
       python: pypy
       env:
-        - TRAVIS_NODE_VERSION=6.12
+        - TRAVIS_NODE_VERSION=8
         - BROWSER=Firefox
     - language: python
       dist: trusty
       python: pypy3
       env:
-        - TRAVIS_NODE_VERSION=8.9
+        - TRAVIS_NODE_VERSION=10
         - BROWSER=Chrome
       addons:
         apt:
@@ -62,22 +65,22 @@ matrix:
             - google-chrome-stable
     # test different versions of Node.js on osx
     - language: node_js
-      node_js: 6.12
+      node_js: 8
       os: osx
       env:
-        - TRAVIS_PYTHON_VERSION=3.4.5
+        - TRAVIS_PYTHON_VERSION=3.5.7
         - BROWSER=PhantomJS
     - language: node_js
-      node_js: 8.9
+      node_js: 10
       os: osx
       env:
-        - TRAVIS_PYTHON_VERSION=3.5.3
+        - TRAVIS_PYTHON_VERSION=3.6.9
         - BROWSER=Safari
     - language: node_js
-      node_js: 9
+      node_js: 12
       os: osx
       env:
-        - TRAVIS_PYTHON_VERSION=3.6.0
+        - TRAVIS_PYTHON_VERSION=3.7.3
         - BROWSER=Safari
 
 before_install:
@@ -105,13 +108,11 @@ before_install:
   - npm --version
 
 install:
-  - pip install coverage flake8
-  # install the required development dependencies as wheels first
-  - pip install calmjs.webpack calmjs.rjs calmjs.dev
-
-  # use development versions of everything else
-  - pip install -e git+https://github.com/calmjs/nunja.git@demo201801#egg=nunja
-  - python setup.py develop
+  # git+https link support requires pip/setuptools be updated manually?
+  - pip install -U coverage flake8 pip setuptools
+  # need this to avoid ambiguity later
+  - pip install -U calmjs.dev calmjs.rjs calmjs.webpack
+  - pip install -e .[dev,rjs,webpack]
 
   # doing the env in this directory to save build time/bandwidth, as the
   # same environment will be used for both Python and JavaScript tests.
@@ -134,20 +135,20 @@ script:
   # - if [[ "$TRAVIS_NODE_VERSION" != "0.12" ]]; then
   #     ./node_modules/.bin/eslint "src/**/*.js" ;
   #   fi
-  - calmjs karma --artifact=nunja.webpack.js -c --cover-test --browser=$BROWSER webpack nunja.stock --build-dir=manual --sourcepath-method=explicit -w
+  - calmjs karma --artifact=nunja.webpack.js -c --cover-test --browser=$BROWSER webpack nunja.stock --sourcepath-method=explicit -w
   - coverage report -m
+
+  # For proper testing of source coverage, provide artifact for nunja.
+  - calmjs rjs --optional-advice=nunja --source-registry=calmjs.module nunja
+  - calmjs karma --artifact=nunja.js --browser=$BROWSER --coverage --cover-test rjs --sourcepath-method=explicit --build-dir=manual -w nunja.stock
+
+  # Finally, for the full standalone artifact for just this package
+  # - calmjs karma --artifact=nunja.js --browser=$BROWSER --coverage --cover-test rjs --sourcepath-method=explicit --bundle-map-method=none -w nunja.stock
 
   # build all artifacts
   - calmjs artifact build nunja.stock
   # test all artifacts
   - calmjs artifact karma --browser=$BROWSER nunja.stock
-
-# Through a specific precompiled artifact
-#  - calmjs rjs --optional-advice=nunja --source-registry=calmjs.module nunja
-#  - calmjs karma --artifact=nunja.js --browser=$BROWSER --coverage --cover-test rjs --source-map-method=explicit -w nunja.stock
-
-# Finally, for the full standalone artifact for just this package
-#  - calmjs karma --artifact=nunja.js --browser=$BROWSER --coverage --cover-test rjs --source-map-method=explicit --bundle-map-method=none --optional-advice=nunja[slim] -w nunja.stock
 
 after_success:
   # only submit coverage when testing under linux.
@@ -174,4 +175,3 @@ branches:
     - testing
     - master
     - 1.0.x
-    - demo201801

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,15 +108,17 @@ install:
   - pip install coverage flake8
   # install the required development dependencies as wheels first
   # - pip install calmjs.rjs calmjs.dev
-  # need development version of calmjs.dev for now
-  - pip install -e git+https://github.com/calmjs/calmjs.dev.git#egg=calmjs.dev
-  - pip install -e git+https://github.com/calmjs/calmjs.rjs.git#egg=calmjs.rjs
-  - pip install -e git+https://github.com/calmjs/nunja.git#egg=nunja
+  # use development versions of everything.
+  - pip install -U -e git+https://github.com/calmjs/calmjs.git#egg=calmjs
+  - pip install -e git+https://github.com/metatoaster/calmjs.dev.git@calmjs3#egg=calmjs.dev
+  - pip install -e git+https://github.com/metatoaster/calmjs.rjs.git@calmjs.parse#egg=calmjs.rjs
+  - pip install -e git+https://github.com/metatoaster/calmjs.webpack.git@calmjs3#egg=calmjs.webpack
+  - pip install -e git+https://github.com/metatoaster/nunja.git@webpack_demo#egg=nunja
   - python setup.py develop
 
   # doing the env in this directory to save build time/bandwidth, as the
   # same environment will be used for both Python and JavaScript tests.
-  - calmjs npm --install nunja.stock[dev] -w -D
+  - calmjs npm --install nunja.stock[dev,rjs,webpack] -w -D
   # out-of-band installation of platform specific dependencies
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       npm install karma-safari-launcher ;
@@ -128,13 +130,14 @@ script:
 
   # generate bundle/tests
   - mkdir manual
-  - calmjs rjs nunja -w --export-target=nunja.js
+  - calmjs webpack nunja -w --export-target=nunja.webpack.js
 
   # eslint 3 only works in nodejs 4+
-  - if [[ "$TRAVIS_NODE_VERSION" != "0.12" ]]; then
-      eslint "src/**/*.js" ;
-    fi
-  - calmjs karma --artifact=nunja.js -c --cover-test --browser=$BROWSER rjs nunja.stock --build-dir=manual --source-map-method=explicit -w
+  # not linting while prototyping a new build system.
+  # - if [[ "$TRAVIS_NODE_VERSION" != "0.12" ]]; then
+  #     ./node_modules/.bin/eslint "src/**/*.js" ;
+  #   fi
+  - calmjs karma --artifact=nunja.webpack.js -c --cover-test --browser=$BROWSER webpack nunja.stock --build-dir=manual --sourcepath-method=explicit -w
   - coverage report -m
 
 # Through a specific precompiled artifact

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,13 +107,10 @@ before_install:
 install:
   - pip install coverage flake8
   # install the required development dependencies as wheels first
-  # - pip install calmjs.rjs calmjs.dev
-  # use development versions of everything.
-  - pip install -U -e git+https://github.com/calmjs/calmjs.git#egg=calmjs
-  - pip install -e git+https://github.com/metatoaster/calmjs.dev.git@calmjs3#egg=calmjs.dev
-  - pip install -e git+https://github.com/metatoaster/calmjs.rjs.git@calmjs.parse#egg=calmjs.rjs
-  - pip install -e git+https://github.com/metatoaster/calmjs.webpack.git@calmjs3#egg=calmjs.webpack
-  - pip install -e git+https://github.com/metatoaster/nunja.git@webpack_demo#egg=nunja
+  - pip install calmjs.webpack calmjs.rjs calmjs.dev
+
+  # use development versions of everything else
+  - pip install -e git+https://github.com/calmjs/nunja.git@demo201801#egg=nunja
   - python setup.py develop
 
   # doing the env in this directory to save build time/bandwidth, as the
@@ -139,6 +136,11 @@ script:
   #   fi
   - calmjs karma --artifact=nunja.webpack.js -c --cover-test --browser=$BROWSER webpack nunja.stock --build-dir=manual --sourcepath-method=explicit -w
   - coverage report -m
+
+  # build all artifacts
+  - calmjs artifact build nunja.stock
+  # test all artifacts
+  - calmjs artifact karma --browser=$BROWSER nunja.stock
 
 # Through a specific precompiled artifact
 #  - calmjs rjs --optional-advice=nunja --source-registry=calmjs.module nunja
@@ -172,3 +174,4 @@ branches:
     - testing
     - master
     - 1.0.x
+    - demo201801

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,57 +6,63 @@ matrix:
     - env: TRAVIS_NODE_VERSION=12
   include:
     - language: python
-      python: 2.7
-      env:
-        - TRAVIS_NODE_VERSION=10
-        - BROWSER=PhantomJS
-    - language: python
       dist: trusty
       python: 3.4
       env:
         - TRAVIS_NODE_VERSION=8
-        - BROWSER=Chrome
+        - BROWSER=PhantomJS
+    - language: python
+      python: 3.5
+      dist: bionic
+      services:
+        - xvfb
       addons:
         apt:
           sources:
             - google-chrome
           packages:
             - google-chrome-stable
-    - language: python
-      python: 3.5
       env:
         - TRAVIS_NODE_VERSION=10
-        - BROWSER=PhantomJS
+        - BROWSER=Chrome
     - language: python
       python: 3.6
+      dist: bionic
+      services:
+        - xvfb
       env:
         - TRAVIS_NODE_VERSION=10
-        - BROWSER=PhantomJS
+        - BROWSER=Firefox
     - language: python
       python: 3.7
       sudo: true
-      dist: xenial
+      dist: bionic
+      services:
+        - xvfb
+      addons:
+        apt:
+          sources:
+            - google-chrome
+          packages:
+            - google-chrome-stable
       env:
         - TRAVIS_NODE_VERSION=10
-        - BROWSER=PhantomJS
+        - BROWSER=Chrome
     - language: python
       python: 3.8-dev
       sudo: true
-      dist: xenial
+      dist: bionic
+      services:
+        - xvfb
       env:
         - TRAVIS_NODE_VERSION=12
-        - BROWSER=PhantomJS
-    - language: python
-      python: pypy
-      env:
-        - TRAVIS_NODE_VERSION=8
         - BROWSER=Firefox
     - language: python
       dist: trusty
       python: pypy3
       env:
         - TRAVIS_NODE_VERSION=10
-        - BROWSER=Chrome
+        - BROWSER=PhantomJS
       addons:
         apt:
           sources:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,22 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      nodejs_version: "4.6"
+      nodejs_version: "6.9"
       BROWSER: "Chrome"
     - PYTHON: "C:\\Python33"
-      nodejs_version: "4.6"
+      nodejs_version: "6.9"
       BROWSER: "Firefox"
     - PYTHON: "C:\\Python34"
-      nodejs_version: "6.9"
+      nodejs_version: "6.12"
       BROWSER: "Chrome"
     - PYTHON: "C:\\Python35"
-      nodejs_version: "6.9"
+      nodejs_version: "6.12"
       BROWSER: "Firefox"
     - PYTHON: "C:\\Python36"
-      nodejs_version: "7.4"
+      nodejs_version: "8.9"
       BROWSER: "IE"
     - PYTHON: "C:\\Python36"
-      nodejs_version: "7.4"
+      nodejs_version: "8.9"
       BROWSER: "PhantomJS"
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,13 +35,16 @@ install:
 
   # - pip install coverage calmjs.dev calmjs.rjs
   - pip install coverage
-  - pip install -e git+https://github.com/calmjs/calmjs.dev.git#egg=calmjs.dev
-  - pip install -e git+https://github.com/calmjs/calmjs.rjs.git#egg=calmjs.rjs
-  - pip install -e git+https://github.com/calmjs/nunja.git#egg=nunja
+
+  - pip install -U -e git+https://github.com/calmjs/calmjs.git#egg=calmjs
+  - pip install -e git+https://github.com/metatoaster/calmjs.dev.git@calmjs3#egg=calmjs.dev
+  - pip install -e git+https://github.com/metatoaster/calmjs.rjs.git@calmjs.parse#egg=calmjs.rjs
+  - pip install -e git+https://github.com/metatoaster/calmjs.webpack.git@calmjs3#egg=calmjs.webpack
+  - pip install -e git+https://github.com/metatoaster/nunja.git@webpack_demo#egg=nunja
   - python setup.py develop
 
   # doing the env in this directory to save build time/bandwidth
-  - calmjs npm --install nunja.stock[dev] -w -D
+  - calmjs npm --install nunja.stock[dev,webpack,rjs] -w -D
   - npm install karma-ie-launcher
   - "SET CALMJS_TEST_ENV=."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,14 +33,9 @@ install:
   - virtualenv --clear venv
   - "venv\\Scripts\\activate.bat"
 
-  # - pip install coverage calmjs.dev calmjs.rjs
-  - pip install coverage
+  - pip install coverage calmjs.dev calmjs.rjs calmjs.webpack
 
-  - pip install -U -e git+https://github.com/calmjs/calmjs.git#egg=calmjs
-  - pip install -e git+https://github.com/metatoaster/calmjs.dev.git@calmjs3#egg=calmjs.dev
-  - pip install -e git+https://github.com/metatoaster/calmjs.rjs.git@calmjs.parse#egg=calmjs.rjs
-  - pip install -e git+https://github.com/metatoaster/calmjs.webpack.git@calmjs3#egg=calmjs.webpack
-  - pip install -e git+https://github.com/metatoaster/nunja.git@webpack_demo#egg=nunja
+  - pip install -e git+https://github.com/calmjs/nunja.git@demo201801#egg=nunja
   - python setup.py develop
 
   # doing the env in this directory to save build time/bandwidth
@@ -55,6 +50,11 @@ test_script:
   # for the JS
   - calmjs rjs nunja -w --export-target=nunja.js
   - calmjs karma --artifact=nunja.js -c --cover-test --browser=%BROWSER% rjs nunja.stock --source-map-method=explicit -w
+
+  # build all artifacts
+  - calmjs artifact build nunja.stock
+  # test all artifacts
+  - calmjs artifact karma --browser=%BROWSER% nunja.stock
 
 artifacts:
   - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,28 +1,23 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      nodejs_version: "6.9"
+      nodejs_version: "8"
       BROWSER: "Chrome"
-    - PYTHON: "C:\\Python33"
-      nodejs_version: "6.9"
-      BROWSER: "Firefox"
     - PYTHON: "C:\\Python34"
-      nodejs_version: "6.12"
+      nodejs_version: "10"
       BROWSER: "Chrome"
     - PYTHON: "C:\\Python35"
-      nodejs_version: "6.12"
+      nodejs_version: "10"
       BROWSER: "Firefox"
     - PYTHON: "C:\\Python36"
-      nodejs_version: "8.9"
+      nodejs_version: "10"
       BROWSER: "IE"
-    - PYTHON: "C:\\Python36"
-      nodejs_version: "8.9"
+    - PYTHON: "C:\\Python37"
+      nodejs_version: "12"
       BROWSER: "PhantomJS"
 matrix:
   allow_failures:
     - BROWSER: "IE"
-    # somehow this is blowing up...
-    - BROWSER: "PhantomJS"
 
 install:
   - choco install firefox
@@ -33,13 +28,14 @@ install:
   - virtualenv --clear venv
   - "venv\\Scripts\\activate.bat"
 
-  - pip install coverage calmjs.dev calmjs.rjs calmjs.webpack
-
-  - pip install -e git+https://github.com/calmjs/nunja.git@demo201801#egg=nunja
-  - python setup.py develop
+  - pip install coverage flake8
+  # need this to avoid ambiguity later
+  - pip install -U calmjs.dev calmjs.rjs calmjs.webpack
+  - pip install -e .[dev,rjs,webpack]
 
   # doing the env in this directory to save build time/bandwidth
   - calmjs npm --install nunja.stock[dev,webpack,rjs] -w -D
+  # out of band installation for IE launcher.
   - npm install karma-ie-launcher
   - "SET CALMJS_TEST_ENV=."
 
@@ -47,9 +43,13 @@ test_script:
   - coverage run -m unittest nunja.stock.tests.make_suite
   - coverage report -m --include=src/*
 
-  # for the JS
+  # with RequireJS
   - calmjs rjs nunja -w --export-target=nunja.js
-  - calmjs karma --artifact=nunja.js -c --cover-test --browser=%BROWSER% rjs nunja.stock --source-map-method=explicit -w
+  - calmjs karma --artifact=nunja.js -c --cover-test --browser=%BROWSER% rjs nunja.stock --sourcepath-method=explicit -w
+
+  # with webpack
+  - calmjs webpack nunja -w --export-target=nunja.webpack.js
+  - calmjs karma --artifact=nunja.webpack.js -c --cover-test --browser=%BROWSER% webpack nunja.stock --sourcepath-method=explicit -w
 
   # build all artifacts
   - calmjs artifact build nunja.stock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
-      nodejs_version: "8"
-      BROWSER: "Chrome"
     - PYTHON: "C:\\Python34"
       nodejs_version: "10"
       BROWSER: "Chrome"
@@ -18,6 +15,7 @@ environment:
 matrix:
   allow_failures:
     - BROWSER: "IE"
+    - BROWSER: "PhantomJS"
 
 install:
   - choco install firefox

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,14 @@ setup(
         ],
         'calmjs.artifacts': [
             'nunja.stock.rjs.js = calmjs.rjs.artifact:complete_rjs',
-
-        ]
+            'nunja.stock.webpack.js'
+            ' = calmjs.webpack.artifact:complete_webpack',
+        ],
+        'calmjs.artifacts.tests': [
+            'nunja.stock.rjs.js = calmjs.rjs.artifact:test_complete_rjs',
+            'nunja.stock.webpack.js'
+            ' = calmjs.webpack.artifact:test_complete_webpack',
+        ],
     },
     test_suite="nunja.stock.tests.make_suite",
 )

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,10 @@ Intended Audience :: Developers
 License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)
 Operating System :: OS Independent
 Programming Language :: JavaScript
-Programming Language :: Python :: 2.7
-Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 """.strip().splitlines()
 
 package_json = {
@@ -66,7 +65,7 @@ setup(
              'calmjs.webpack',
         ],
     },
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=3.4',
     build_calmjs_artifacts=True,
     entry_points={
         'calmjs.module': [

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     extras_require={
         'dev': [
             'calmjs.dev>=1.0.2,<2',
+            'calmjs.parse>=1.0.0,<2',
         ],
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         ],
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    build_calmjs_artifacts=True,
     entry_points={
         'calmjs.module': [
             'nunja.stock = nunja.stock',
@@ -65,6 +66,10 @@ setup(
         'nunja.mold': [
             'nunja.stock.molds = nunja.stock:molds',
         ],
+        'calmjs.artifacts': [
+            'nunja.stock.rjs.js = calmjs.rjs.artifact:complete_rjs',
+
+        ]
     },
     test_suite="nunja.stock.tests.make_suite",
 )

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,13 @@ Programming Language :: Python :: 3.6
 """.strip().splitlines()
 
 package_json = {
-    "dependencies": {},
+    "dependencies": {
+        "webpack": "~4.16.0",
+        "webpack-cli": "~3.0.0",
+    },
     "devDependencies": {
         "eslint": "~3.15.0",
-    }
+    },
 }
 
 long_description = (
@@ -46,8 +49,10 @@ setup(
     zip_safe=False,
     package_json=package_json,
     install_requires=[
-        'nunja',
-        'uritemplate',
+        'nunja'
+        ' @ git+https://github.com/calmjs/nunja.git@master',
+        'uritemplate'
+        ' @ git+https://github.com/python-hyper/uritemplate.git@df03b63b7',
     ],
     extras_require={
         'dev': [
@@ -82,6 +87,9 @@ setup(
             'nunja.stock.rjs.js = calmjs.rjs.artifact:test_complete_rjs',
             'nunja.stock.webpack.js'
             ' = calmjs.webpack.artifact:test_complete_webpack',
+        ],
+        'calmjs.toolchain.advice.apply': [
+            'nunja = nunja',
         ],
     },
     test_suite="nunja.stock.tests.make_suite",

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,14 @@ setup(
     ],
     extras_require={
         'dev': [
-            'calmjs.dev>=1.0.2,<2',
+            'calmjs.dev>=1.0.2,<3',
             'calmjs.parse>=1.0.0,<2',
+        ],
+        'rjs': [
+             'calmjs.rjs',
+        ],
+        'webpack': [
+             'calmjs.webpack',
         ],
     },
     python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',

--- a/src/nunja/stock/model/base.py
+++ b/src/nunja/stock/model/base.py
@@ -3,18 +3,26 @@
 Base server-side UI component model
 """
 
+import json
 from collections import namedtuple
 
 from uritemplate import expand
 
 
 def clone_dict(d):
-    o = {}
+    result = {}
     if d:
-        if not isinstance(d, dict):
-            raise TypeError('provided value must be falsy or dict')
-        o.update(d)
-    return o
+        if isinstance(d, dict):
+            result.update(d)
+        else:
+            try:
+                v = json.loads(d)
+            except Exception:
+                v = NotImplemented
+            if not isinstance(v, dict):
+                raise TypeError('provided value must be falsy or dict')
+            result.update(v)
+    return result
 
 
 class Definition(namedtuple('Definition', [
@@ -61,7 +69,8 @@ class Definition(namedtuple('Definition', [
         The attributes for the css classes
 
     config
-        Extra configuration for the template.
+        Extra configuration for the template.  Provided either as JSON
+        string or a dict that can be encoded as JSON.
 
     context
         The context for the linked data.

--- a/src/nunja/stock/model/base.py
+++ b/src/nunja/stock/model/base.py
@@ -40,9 +40,22 @@ class Definition(namedtuple('Definition', [
     uri_template_json
         This is the template for all the URIs that will be generated
         for all the navigational links for getting to the JSON for
-        that particular record.
+        that particular record, if set to a specific string.
 
-        Defaults to unspecified
+        If True is set, the uri_template will be used as is with the
+        json_cache_suffix applied.
+
+        If a falsy value is set, no uri_template_json will be defined
+        and this typically mean no data-href will be provided.
+
+        Defaults to None
+
+    json_cache_suffix
+        A string that will be appended to the default uri_template_json
+        as it would be identical to uri_template.  Set this to an empty
+        string if the browser cache workaround is not required.
+
+        Defaults to: '?'
 
     css_class
         The attributes for the css classes
@@ -60,8 +73,12 @@ class Definition(namedtuple('Definition', [
     def __new__(
             cls,
             nunja_model_id, uri_template, uri_template_json=None,
+            json_cache_suffix='?',
             css_class=None, config=None, context='https://schema.org/',
             ):
+
+        if uri_template_json is True:
+            uri_template_json = uri_template + json_cache_suffix
 
         return cls.__bases__[0].__new__(
             cls,

--- a/src/nunja/stock/model/breadcrumb.py
+++ b/src/nunja/stock/model/breadcrumb.py
@@ -42,7 +42,7 @@ class Simple(Base):
             ),
         }
 
-    def make_breadcrumb(self, url):
+    def make_breadcrumb_from_url(self, url):
         """
         Simply split the path.
         """
@@ -70,5 +70,5 @@ class Simple(Base):
             ]
         }}
 
-    def get_breadcrumb(self, url):
-        return self.finalize(self.make_breadcrumb(url))
+    def get_breadcrumb_from_url(self, url):
+        return self.finalize(self.make_breadcrumb_from_url(url))

--- a/src/nunja/stock/model/fsnav.py
+++ b/src/nunja/stock/model/fsnav.py
@@ -12,6 +12,7 @@ from os.path import join
 from os.path import isdir
 from os.path import normpath
 from os.path import sep
+from types import MappingProxyType
 
 from posixpath import normpath as normuri
 from posixpath import dirname as diruri
@@ -171,6 +172,7 @@ class Base(base.Base):
             anchor_key=None,
             uri_template_path_key=None,
             uri_template_json_path_key=None,
+            uri_template_vars={},
             type_definitions=None,
             ):
         """
@@ -203,6 +205,10 @@ class Base(base.Base):
             provided as part of a separate system that is also shared
             and used here.
 
+        uri_template_vars
+            An mapping of variables to be provided to both templates
+            for formatting.
+
         type_definitions
             Type specific definitions - allow specific definitions to
             be used for the finalizing part.
@@ -223,6 +229,7 @@ class Base(base.Base):
             definition.uri_template_tmpl) or 'path'
         self.uri_template_json_path_key = self.find_uri_template_explode_key(
             definition.uri_template_json_tmpl) or 'path'
+        self.uri_template_vars = MappingProxyType(uri_template_vars)
 
     @staticmethod
     def find_uri_template_explode_key(tmpl):
@@ -247,11 +254,17 @@ class Base(base.Base):
             for key in set(fsnav_keys) - set(self.active_keys):
                 result.pop(key, None)
 
-            result['url'] = self.definition.format_href(
-                **{self.uri_template_path_key: path})
+            values = {}
+            values.update(self.uri_template_vars)
+            values[self.uri_template_path_key] = path
+
+            result['url'] = self.definition.format_href(**values)
             if self.definition.uri_template_json:
+                values = {}
+                values.update(self.uri_template_vars)
+                values[self.uri_template_json_path_key] = path
                 result['data_href'] = self.definition.format_data_href(
-                    **{self.uri_template_json_path_key: path})
+                    **values)
             return result
 
         return f_filter

--- a/src/nunja/stock/model/fsnav.py
+++ b/src/nunja/stock/model/fsnav.py
@@ -78,7 +78,7 @@ class FSModel(object):
 
     def _fs_path_format_path(self, fs_path):
         trail = [''] if isdir(fs_path) else []
-        return '/'.join(normpath(fs_path)[len(self.root):].split(sep) + trail)
+        return normpath(fs_path)[len(self.root):].split(sep)[1:] + trail
 
     def _listdir(self, fs_path):
         """
@@ -248,7 +248,7 @@ class Base(base.Base):
             part_of = None
             for key, value in attrs:
                 if key == 'path':
-                    part_of = value
+                    part_of = '/'.join(value)
                 if key not in self.active_keys:
                     continue
                 rownames.append(key)

--- a/src/nunja/stock/testing/case.py
+++ b/src/nunja/stock/testing/case.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import codecs
 import json
 import unittest
 
@@ -24,8 +25,9 @@ class ExamplesTestCase(unittest.TestCase):
             raise ValueError(
                 'the class must define the test_examples attribute for data')
 
-        with open(resource_filename(
-                cls.test_module_name, cls.test_examples)) as fd:
+        with codecs.open(
+                resource_filename(cls.test_module_name, cls.test_examples),
+                encoding='utf8') as fd:
             cls.data = json.loads(str(es5(fd.read()).children()[0].children(
                 )[0].initializer))
             # TODO also sanity check the resulting object?

--- a/src/nunja/stock/testing/case.py
+++ b/src/nunja/stock/testing/case.py
@@ -4,7 +4,7 @@ import unittest
 
 from pkg_resources import resource_filename
 
-from calmjs.rjs.ecma import parse
+from calmjs.parse import es5
 
 
 class ExamplesTestCase(unittest.TestCase):
@@ -26,8 +26,8 @@ class ExamplesTestCase(unittest.TestCase):
 
         with open(resource_filename(
                 cls.test_module_name, cls.test_examples)) as fd:
-            cls.data = json.loads(parse(fd.read()).children()[0].children(
-                )[0].initializer.to_ecma())
+            cls.data = json.loads(str(es5(fd.read()).children()[0].children(
+                )[0].initializer))
             # TODO also sanity check the resulting object?
 
     def assertDataEqual(self, key, result):

--- a/src/nunja/stock/testing/loader.py
+++ b/src/nunja/stock/testing/loader.py
@@ -3,7 +3,7 @@ import unittest
 import json
 from pkg_resources import resource_filename
 
-from calmjs.rjs.ecma import parse
+from calmjs.parse import es5
 
 from nunja.core import engine
 
@@ -46,7 +46,7 @@ def generate_test(name, mold_id, test_module_ns, data_module):
 
     with open(resource_filename(test_module_ns, data_module + '.js')) as fd:
         data = json.loads(
-            parse(fd.read()).children()[0].children()[0].initializer.to_ecma())
+            str(es5(fd.read()).children()[0].children()[0].initializer))
 
     attrs = {
         'maxDiff': None,

--- a/src/nunja/stock/testing/loader.py
+++ b/src/nunja/stock/testing/loader.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+import codecs
 import json
 from pkg_resources import resource_filename
 
@@ -44,7 +45,9 @@ def generate_test(name, mold_id, test_module_ns, data_module):
 
         return _method
 
-    with open(resource_filename(test_module_ns, data_module + '.js')) as fd:
+    with codecs.open(
+            resource_filename(test_module_ns, data_module + '.js'),
+            encoding='utf8') as fd:
         data = json.loads(
             str(es5(fd.read()).children()[0].children()[0].initializer))
 

--- a/src/nunja/stock/tests/breadcrumb_examples.js
+++ b/src/nunja/stock/tests/breadcrumb_examples.js
@@ -83,6 +83,55 @@ var exports = {
         "</div>"
     ]],
 
+    "three item empty final fragment":
+    [{
+        "@context": "https://schema.org/",
+        "nunja_model_config": {},
+        "nunja_model_id": "model_id",
+        "mainEntity": {
+            "@type": "BreadcrumbList",
+            "itemListElement": [{
+                "@type": "ListItem",
+                "position": 1,
+                "item": {
+                    "@id": "https://example.com/",
+                    "name": "Home",
+                },
+            }, {
+                "@type": "ListItem",
+                "position": 2,
+                "item": {
+                    "@id": "https://example.com/documents/",
+                    "name": "documents",
+                },
+            }, {
+                "@type": "ListItem",
+                "position": 3,
+                "item": {
+                    "@id": "https://example.com/documents/subfolder/",
+                    "name": "subfolder",
+                },
+            }, {
+                "@type": "ListItem",
+                "position": 4,
+                "item": {
+                    "@id": "https://example.com/documents/subfolder/targets/",
+                    "name": "targets",
+                },
+            }]
+        },
+        "meta": {"css_class": {}},
+    }, [
+        "<div data-nunja=\"nunja.stock.molds/breadcrumb\">",
+        "<ol class=\"\">",
+        "  <li><a href=\"https://example.com/\">Home</a></li>",
+        "  <li><a href=\"https://example.com/documents/\">documents</a></li>",
+        "  <li><a href=\"https://example.com/documents/subfolder/\">subfolder</a></li>",
+        "  <li><a href=\"https://example.com/documents/subfolder/targets/\">targets</a></li>",
+        "</ol>",
+        "</div>"
+    ]],
+
     "complete example":
     [{
         "@context": "https://schema.org/",

--- a/src/nunja/stock/tests/loader.js
+++ b/src/nunja/stock/tests/loader.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// var core = require('nunja/core');
+var core = require('nunja/core');
 
 var GenerateTestFactory = function(core, test_lib) {
     return function(name, mold_id, data_module) {

--- a/src/nunja/stock/tests/test_loader.js
+++ b/src/nunja/stock/tests/test_loader.js
@@ -17,7 +17,11 @@ var fake_data = {
 };
 
 
-describe('test loader tests', function() {
+/* istanbul ignore next */
+var describe_ = (typeof requirejs == 'undefined') ? describe.skip : describe;
+
+
+describe_('test loader tests', function() {
 
     beforeEach(function() {
         this.clock = sinon.useFakeTimers();
@@ -55,8 +59,10 @@ describe('test loader tests', function() {
 
     afterEach(function() {
         window.nunjucksPrecompiled = this.nunjucksPrecompiled;
-        requirejs.undef('__nunja__/dummy/mold');
-        requirejs.undef('data');
+        if ((typeof requirejs != 'undefined') && requirejs.undef) {
+            requirejs.undef('__nunja__/dummy/mold');
+            requirejs.undef('data');
+        }
     });
 
     it('test_run', function(done) {

--- a/src/nunja/stock/tests/test_model_base.py
+++ b/src/nunja/stock/tests/test_model_base.py
@@ -18,7 +18,8 @@ class DefinitionTestCase(unittest.TestCase):
     def test_definition_construction_all_parameters(self):
         defn = base.Definition(
             'model_id', 'https://example.com/{path}',
-            uri_template_json='https://example.com/{path}?',
+            uri_template_json=True,
+            json_cache_suffix=';',
             css_class={'body': 'tagged'},
             config={'extra_mold': 'nunja.example/mold'},
             context=[
@@ -28,13 +29,38 @@ class DefinitionTestCase(unittest.TestCase):
         )
         self.assertEqual(defn.nunja_model_id, 'model_id')
         self.assertEqual(defn.uri_template, 'https://example.com/{path}')
-        self.assertEqual(defn.uri_template_json, 'https://example.com/{path}?')
+        self.assertEqual(defn.uri_template_json, 'https://example.com/{path};')
         self.assertEqual(defn.css_class, {'body': 'tagged'})
         self.assertEqual(defn.config, {'extra_mold': 'nunja.example/mold'})
         self.assertEqual(defn.context, [
             "http://schema.org",
             {"image": {"@id": "schema:image", "@type": "@id"}},
         ])
+
+    def test_definition_uri_template_json(self):
+        defn = base.Definition(
+            'model_id', 'https://example.com/{path}',
+            uri_template_json=True,
+        )
+        self.assertEqual(defn.uri_template_json, 'https://example.com/{path}?')
+
+        # explicit template will not have a json_cache_suffix applied.
+        defn = base.Definition(
+            'model_id', 'https://example.com/{path}',
+            uri_template_json='https://api.example.com/{path}',
+            json_cache_suffix=';',
+        )
+        self.assertEqual(
+            defn.uri_template_json, 'https://api.example.com/{path}')
+
+        # the way to set uri_template_json to be equal to uri_template
+        # without repeating it
+        defn = base.Definition(
+            'model_id', 'https://example.com/{path}',
+            uri_template_json=True,
+            json_cache_suffix='',
+        )
+        self.assertEqual(defn.uri_template_json, 'https://example.com/{path}')
 
     def test_definition_construction_error(self):
         with self.assertRaises(TypeError):

--- a/src/nunja/stock/tests/test_model_base.py
+++ b/src/nunja/stock/tests/test_model_base.py
@@ -37,6 +37,28 @@ class DefinitionTestCase(unittest.TestCase):
             {"image": {"@id": "schema:image", "@type": "@id"}},
         ])
 
+    def test_definition_construction_all_dict_param_jsonstr(self):
+        defn = base.Definition(
+            'model_id', 'https://example.com/{path}',
+            uri_template_json=True,
+            json_cache_suffix=';',
+            css_class='{"body": "tagged"}',
+            config='{"extra_mold": "nunja.example/mold"}',
+            context=[
+                "http://schema.org",
+                {"image": {"@id": "schema:image", "@type": "@id"}},
+            ],
+        )
+        self.assertEqual(defn.nunja_model_id, 'model_id')
+        self.assertEqual(defn.uri_template, 'https://example.com/{path}')
+        self.assertEqual(defn.uri_template_json, 'https://example.com/{path};')
+        self.assertEqual(defn.css_class, {'body': 'tagged'})
+        self.assertEqual(defn.config, {'extra_mold': 'nunja.example/mold'})
+        self.assertEqual(defn.context, [
+            "http://schema.org",
+            {"image": {"@id": "schema:image", "@type": "@id"}},
+        ])
+
     def test_definition_uri_template_json(self):
         defn = base.Definition(
             'model_id', 'https://example.com/{path}',

--- a/src/nunja/stock/tests/test_model_breadcrumb.py
+++ b/src/nunja/stock/tests/test_model_breadcrumb.py
@@ -14,13 +14,19 @@ class SimpleTestCase(ExamplesTestCase):
             'model_id', 'https://example.com{+path}'))
 
     def test_root_item(self):
-        self.assertDataEqual('root item', self.breadcrumb.get_breadcrumb(
-            'https://example.com/'))
+        self.assertDataEqual(
+            'root item',
+            self.breadcrumb.get_breadcrumb_from_url('https://example.com/')
+        )
 
     def test_two_items(self):
-        self.assertDataEqual('two items', self.breadcrumb.get_breadcrumb(
-            '/documents/item'))
+        self.assertDataEqual(
+            'two items',
+            self.breadcrumb.get_breadcrumb_from_url('/documents/item')
+        )
 
     def test_two_items_relative_path(self):
-        self.assertDataEqual('two items', self.breadcrumb.get_breadcrumb(
-            'documents/item'))
+        self.assertDataEqual(
+            'two items',
+            self.breadcrumb.get_breadcrumb_from_url('documents/item')
+        )

--- a/src/nunja/stock/tests/test_model_breadcrumb.py
+++ b/src/nunja/stock/tests/test_model_breadcrumb.py
@@ -4,29 +4,55 @@ from nunja.stock.model import breadcrumb
 from nunja.stock.testing.case import ExamplesTestCase
 
 
-class SimpleTestCase(ExamplesTestCase):
+class FragmentBCTestCase(ExamplesTestCase):
 
-    maxDiff = None
     test_examples = 'breadcrumb_examples.js'
 
     def setUp(self):
-        self.breadcrumb = breadcrumb.Simple(Definition(
-            'model_id', 'https://example.com{+path}'))
+        self.breadcrumb = breadcrumb.FragmentBC(Definition(
+            'model_id', 'https://example.com{/path*}'))
 
     def test_root_item(self):
         self.assertDataEqual(
             'root item',
-            self.breadcrumb.get_breadcrumb_from_url('https://example.com/')
+            self.breadcrumb.get_breadcrumb([''])
         )
 
     def test_two_items(self):
         self.assertDataEqual(
             'two items',
-            self.breadcrumb.get_breadcrumb_from_url('/documents/item')
+            self.breadcrumb.get_breadcrumb(['documents', 'item'])
         )
 
     def test_two_items_relative_path(self):
         self.assertDataEqual(
             'two items',
-            self.breadcrumb.get_breadcrumb_from_url('documents/item')
+            self.breadcrumb.get_breadcrumb(['documents', 'item'])
+        )
+
+
+class PathBCTestCase(ExamplesTestCase):
+
+    test_examples = 'breadcrumb_examples.js'
+
+    def setUp(self):
+        self.breadcrumb = breadcrumb.PathBC(Definition(
+            'model_id', 'https://example.com{+path}'))
+
+    def test_root_item(self):
+        self.assertDataEqual(
+            'root item',
+            self.breadcrumb.get_breadcrumb_from_uri('https://example.com/')
+        )
+
+    def test_two_items(self):
+        self.assertDataEqual(
+            'two items',
+            self.breadcrumb.get_breadcrumb_from_uri('/documents/item')
+        )
+
+    def test_two_items_relative_path(self):
+        self.assertDataEqual(
+            'two items',
+            self.breadcrumb.get_breadcrumb_from_uri('documents/item')
         )

--- a/src/nunja/stock/tests/test_model_breadcrumb.py
+++ b/src/nunja/stock/tests/test_model_breadcrumb.py
@@ -12,6 +12,30 @@ class FragmentBCTestCase(ExamplesTestCase):
         self.breadcrumb = breadcrumb.FragmentBC(Definition(
             'model_id', 'https://example.com{/path*}'))
 
+    def test_norm_fragments(self):
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            []), ['', ''])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['']), ['', ''])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['foo']), ['', 'foo'])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['', 'foo']), ['', 'foo'])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['foo', '']), ['', 'foo', ''])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['foo', 'bar', 'baz']), ['', 'foo', 'bar', 'baz'])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['', 'foo', 'bar', 'baz']), ['', 'foo', 'bar', 'baz'])
+        self.assertEqual(self.breadcrumb.norm_fragments(
+            ['foo', 'bar', 'baz', '']), ['', 'foo', 'bar', 'baz', ''])
+
+    def test_empty(self):
+        self.assertDataEqual(
+            'root item',
+            self.breadcrumb.get_breadcrumb([])
+        )
+
     def test_root_item(self):
         self.assertDataEqual(
             'root item',
@@ -24,10 +48,13 @@ class FragmentBCTestCase(ExamplesTestCase):
             self.breadcrumb.get_breadcrumb(['documents', 'item'])
         )
 
-    def test_two_items_relative_path(self):
+    def test_three_items_trailing_empty_fragment(self):
+        # this can arise from destructuring a uri fragment such as
+        # 'document/item/' by splitting by '/'
         self.assertDataEqual(
-            'two items',
-            self.breadcrumb.get_breadcrumb(['documents', 'item'])
+            'three item empty final fragment',
+            self.breadcrumb.get_breadcrumb(
+                ['documents', 'subfolder', 'targets', ''])
         )
 
 
@@ -55,4 +82,11 @@ class PathBCTestCase(ExamplesTestCase):
         self.assertDataEqual(
             'two items',
             self.breadcrumb.get_breadcrumb_from_uri('documents/item')
+        )
+
+    def test_three_items_trailing_empty_fragment(self):
+        self.assertDataEqual(
+            'three item empty final fragment',
+            self.breadcrumb.get_breadcrumb_from_uri(
+                '/documents/subfolder/targets/')
         )

--- a/src/nunja/stock/tests/test_model_fsnav.py
+++ b/src/nunja/stock/tests/test_model_fsnav.py
@@ -47,9 +47,9 @@ def create_test_data(testcase):
 class MiscTestCase(unittest.TestCase):
 
     def test_to_filetype(self):
-        self.assertEqual(fsnav.to_filetype(0o100000), 'file')
-        self.assertEqual(fsnav.to_filetype(0o40000), 'folder')
-        self.assertEqual(fsnav.to_filetype(0), 'unknown')
+        self.assertEqual(fsnav.statmap.get(0o100000, 'unknown'), 'file')
+        self.assertEqual(fsnav.statmap.get(0o40000, 'unknown'), 'folder')
+        self.assertEqual(fsnav.statmap.get(0, 'unknown'), 'unknown')
 
     def test_base_get_filetype(self):
         create_test_data(self)

--- a/src/nunja/stock/tests/test_model_fsnav.py
+++ b/src/nunja/stock/tests/test_model_fsnav.py
@@ -73,7 +73,7 @@ class FSModelTestCase(unittest.TestCase):
                 'size': 22,
                 '@id': 'test_file.txt',
                 'name': 'test_file.txt',
-                'path': '/test_file.txt'
+                'path': ['test_file.txt'],
             }
         )
 
@@ -85,7 +85,7 @@ class FSModelTestCase(unittest.TestCase):
                 'alternativeType': 'folder',
                 '@id': 'dummydir1',
                 'name': 'dummydir1',
-                'path': '/dummydir1/'
+                'path': ['dummydir1', ''],
             }
         )
 
@@ -96,7 +96,7 @@ class FSModelTestCase(unittest.TestCase):
                 'size': 13,
                 '@id': 'file1',
                 'name': 'file1',
-                'path': '/dummydir2/file1'
+                'path': ['dummydir2', 'file1'],
             }
         )
 
@@ -112,7 +112,7 @@ class FSModelTestCase(unittest.TestCase):
                 'size': 0,
                 '@id': '..',
                 'name': '..',
-                'path': '/',
+                'path': [''],
             }
         )
 
@@ -147,13 +147,13 @@ class FSModelTestCase(unittest.TestCase):
             '@type': 'ItemList',
             '@id': 'dummydir1',
             'name': 'dummydir1',
-            'path': '/dummydir1/',
+            'path': ['dummydir1', ''],
         })
         self.assertEqual(len(result['mainEntity']['itemListElement']), 1)
         self.assertEqual(
             result['mainEntity']['itemListElement'][0]['name'], '..')
         self.assertEqual(
-            result['mainEntity']['itemListElement'][0]['path'], '/')
+            result['mainEntity']['itemListElement'][0]['path'], [''])
 
     def test_get_struct_dir_contents(self):
         model = fsnav.FSModel(self.tmpdir)
@@ -165,7 +165,7 @@ class FSModelTestCase(unittest.TestCase):
             '@type': 'ItemList',
             '@id': 'dummydir2',
             'name': 'dummydir2',
-            'path': '/dummydir2/',
+            'path': ['dummydir2', ''],
         })
         self.assertEqual(len(result['mainEntity']['itemListElement']), 4)
 
@@ -181,7 +181,7 @@ class FSModelTestCase(unittest.TestCase):
                 'size': 22,
                 '@id': 'test_file.txt',
                 'name': 'test_file.txt',
-                'path': '/test_file.txt',
+                'path': ['test_file.txt'],
             }
         )
 
@@ -194,7 +194,7 @@ class FSModelTestCase(unittest.TestCase):
                 'size': 13,
                 '@id': 'file1',
                 'name': 'file1',
-                'path': '/dummydir2/file1',
+                'path': ['dummydir2', 'file1'],
             }
         )
 
@@ -217,23 +217,23 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_base_model_initialize(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         self.assertEqual(len(model.active_keys), 4)
 
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir,
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir,
             active_keys=['size'])
         self.assertEqual(len(model.active_keys), 1)
         self.assertIsNone(model.anchor_key)
 
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir,
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir,
             anchor_key='name')
         self.assertEqual(model.anchor_key, 'name')
 
     def test_finalize(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         self.assertEqual(model.finalize({}), {
             '@context': 'https://schema.org/',
             'nunja_model_id': 'fsnav',
@@ -254,7 +254,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_finalize_config(self):
         model = fsnav.Base(
-            Definition('static', '/script.py?{+path}', config={
+            Definition('static', '/script.py?{/path*}', config={
                 'key1': 'value1'}),
             self.tmpdir,
         )
@@ -295,7 +295,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_finalize_value_result(self):
         model = fsnav.Base(
-            Definition('static', '/script.py?{+path}'), self.tmpdir)
+            Definition('static', '/script.py?{/path*}'), self.tmpdir)
 
         value = {'mainEntity': {}}
         self.assertEqual(model.finalize(value), {
@@ -336,7 +336,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_get_struct_file(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'),
+            Definition('fsnav', '/script.py?{/path*}'),
             self.tmpdir,
             active_keys=['alternativeType', 'name', 'size'],
         )
@@ -373,7 +373,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_get_struct_dir(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir,
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir,
             anchor_key='name')
 
         result = model._get_struct_dir(self.dummydir1, lambda x: True)
@@ -430,7 +430,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_get_struct_errors(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
 
         errored = model.get_struct('readme.txt')
         self.assertEqual(errored['error'], 'path "/readme.txt" not found')
@@ -439,20 +439,20 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_get_struct_file_success(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         results = model.get_struct('/test_file.txt')
         self.assertEqual(results['mainEntity']['size'], 22)
 
     def test_get_struct_file_parent_traversal_failure(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         target = '/'.join(['..', basename(self.tmpdir), 'test_file.txt'])
         results = model.get_struct(target)
         self.assertEqual(results['error'], 'path "/%s" not found' % target)
 
     def test_get_struct_dir_success(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         results = model.get_struct('/dummydir2')
         self.assertEqual(len(results['mainEntity']['itemListElement']), 4)
 
@@ -462,7 +462,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_get_struct_dir_dirs(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         results = model.get_struct_dirs_only('/dummydir2')
         self.assertEqual(len(results['mainEntity']['itemListElement']), 2)
 
@@ -476,7 +476,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
 
     def test_get_struct_dir_files(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'), self.tmpdir)
+            Definition('fsnav', '/script.py?{/path*}'), self.tmpdir)
         results = model.get_struct_files_only('/dummydir2')
         self.assertEqual(len(results['mainEntity']['itemListElement']), 2)
 
@@ -501,7 +501,7 @@ class FSNavTreeModelMirrorTestCase(ExamplesTestCase):
 
     def test_get_struct_dir_success_limited_columns_no_data(self):
         model = fsnav.Base(
-            Definition('fsnav', '/script.py?{+path}'),
+            Definition('fsnav', '/script.py?{/path*}'),
             self.tmpdir, active_keys=['name', 'alternativeType', 'size'],
         )
         results = model.get_struct('/dummydir2')
@@ -510,8 +510,8 @@ class FSNavTreeModelMirrorTestCase(ExamplesTestCase):
     def test_get_struct_dir_success_limited_columns_with_data(self):
         model = fsnav.Base(
             Definition(
-                'fsnav', '/script.py?{+path}',
-                uri_template_json='/json.py?{+path}',
+                'fsnav', '/script.py?{/path*}',
+                uri_template_json='/json.py?{/path*}',
             ),
             self.tmpdir, active_keys=['name', 'alternativeType', 'size'],
         )
@@ -521,7 +521,7 @@ class FSNavTreeModelMirrorTestCase(ExamplesTestCase):
     def test_get_struct_file_success_limited_columns_no_data(self):
         model = fsnav.Base(
             Definition(
-                'fsnav', '/script.py?{+path}',
+                'fsnav', '/script.py?{/path*}',
             ),
             self.tmpdir, active_keys=['name', 'alternativeType', 'size'],
         )
@@ -532,8 +532,8 @@ class FSNavTreeModelMirrorTestCase(ExamplesTestCase):
     def test_get_struct_file_success_limited_columns_with_data(self):
         model = fsnav.Base(
             Definition(
-                'fsnav', '/script.py?{+path}',
-                uri_template_json='/json.py?{+path}',
+                'fsnav', '/script.py?{/path*}',
+                uri_template_json='/json.py?{/path*}',
             ),
             self.tmpdir, active_keys=['name', 'alternativeType', 'size'],
         )

--- a/src/nunja/stock/tests/test_model_fsnav.py
+++ b/src/nunja/stock/tests/test_model_fsnav.py
@@ -467,6 +467,13 @@ class FSNavTreeModelTestCase(unittest.TestCase):
             }
         )
 
+        model = fsnav.Base(
+            Definition('fsnav', '/root/{additional}{/some_alt_key*}'),
+            self.tmpdir,
+            active_keys=['alternativeType', 'name', 'size'],
+            uri_template_vars={'additional': 'foo'}
+        )
+
         self.assertEqual(
             _dict_clone_filtered(model._get_struct_file(self.dummydirfile1)[
                 'mainEntity'
@@ -476,7 +483,7 @@ class FSNavTreeModelTestCase(unittest.TestCase):
                 'size': 13,
                 '@id': 'file1',
                 'name': 'file1',
-                'url': '/root/dummydir2/file1',
+                'url': '/root/foo/dummydir2/file1',
                 'rownames': ['alternativeType', 'name', 'size'],
                 'rows': [['file'], ['file1'], [13]],
             }
@@ -511,33 +518,6 @@ class FSNavTreeModelTestCase(unittest.TestCase):
         self.assertEqual(result['nunja_model_config'], {
             'mold_id': 'nunja.stock.molds/navgrid',
         })
-
-        # TODO should test out the other conditions here, but this is
-        # covered later with the specialized methods
-        result = model._get_struct_dir(self.dummydir2, lambda x: True)
-        self.assertEqual(_dict_clone_filtered(result['mainEntity'], [
-                'created', 'size', 'itemListElement',
-            ]), {
-                'alternativeType': 'folder',
-                '@type': 'ItemList',
-                '@id': 'dummydir2',
-                'name': 'dummydir2',
-                'url': '/root/dummydir2/',
-
-                'key_label_map': {
-                    'alternativeType': 'type',
-                    'created': 'created',
-                    'name': 'name',
-                    'size': 'size',
-                },
-                'active_keys': ['alternativeType', 'name', 'size', 'created'],
-                'anchor_key': 'name',
-            }
-        )
-        self.assertEqual(result['nunja_model_config'], {
-            'mold_id': 'nunja.stock.molds/navgrid',
-        })
-        self.assertEqual(len(result['mainEntity']['itemListElement']), 4)
 
     def test_get_struct_errors(self):
         model = fsnav.Base(

--- a/src/nunja/stock/tests/test_mold_model_hook.js
+++ b/src/nunja/stock/tests/test_mold_model_hook.js
@@ -2,8 +2,9 @@
 
 window.mocha.setup('bdd');
 
+var describe_ = (typeof requirejs == 'undefined') ? describe.skip : describe;
 
-describe('nunja.stock.molds/model/hook', function() {
+describe_('nunja.stock.molds/model/hook', function() {
 
     var hook = require('nunja.stock.molds/model/hook');
 

--- a/src/nunja/stock/tests/test_mold_model_hook.js
+++ b/src/nunja/stock/tests/test_mold_model_hook.js
@@ -80,5 +80,3 @@ describe('nunja.stock.molds/model/hook', function() {
     });
 
 });
-
-

--- a/src/nunja/stock/tests/test_mold_model_index.js
+++ b/src/nunja/stock/tests/test_mold_model_index.js
@@ -8,6 +8,10 @@ var model_navgrid_data = require('nunja/stock/tests/model_navgrid_data');
 
 window.mocha.setup('bdd');
 
+/* istanbul ignore next */
+var describe_ = (typeof requirejs == 'undefined') ? describe.skip : describe;
+var it_ = (typeof requirejs == 'undefined') ? it.skip : it;
+
 
 var setup_window_event_listener = function(testcase) {
     // setup the cleanup for window event listeners
@@ -32,7 +36,7 @@ var teardown_window_event_listener = function(testcase) {
 };
 
 
-describe('nunja.stock.molds/model test cases', function() {
+describe_('nunja.stock.molds/model test cases', function() {
 
     var data = model_navgrid_data;
     var markers = {};
@@ -146,7 +150,9 @@ describe('nunja.stock.molds/model test cases', function() {
 
     afterEach(function() {
         markers = {};
-        requirejs.undef('nunja.stock.custom/error_handler');
+        if ((typeof requirejs !== 'undefined') && requirejs.undef) {
+            requirejs.undef('nunja.stock.custom/error_handler');
+        }
         this.server.restore();
         this.clock.restore();
         // TODO ideally, all the history should be wiped.
@@ -293,11 +299,11 @@ describe('nunja.stock.molds/model test cases', function() {
 });
 
 
-describe('nunja.stock.molds/model inner model tests', function() {
+describe_('nunja.stock.molds/model inner model tests', function() {
 
     var data = model_navgrid_data;
     var result_items = [];
-    var _defaultOnError = requirejs.onError;
+    var _defaultOnError;
 
     var demo_module_name = 'nunja.molds.demo/module/index';
     var demo_module = {
@@ -327,15 +333,20 @@ describe('nunja.stock.molds/model inner model tests', function() {
         }
 
         setup_window_event_listener(this);
+        if ((typeof requirejs !== 'undefined') && requirejs.undef) {
+            _defaultOnError = requirejs.onError;
+        }
     });
 
     afterEach(function() {
         teardown_window_event_listener(this);
         this.server.restore();
         this.clock.restore();
-        requirejs.undef(demo_module_name);
+        if ((typeof requirejs !== 'undefined') && requirejs.undef) {
+            requirejs.undef(demo_module_name);
+            requirejs.onError = _defaultOnError;
+        }
         result_items = [];
-        requirejs.onError = _defaultOnError;
     });
 
     it('inner missing div', function() {
@@ -700,7 +711,7 @@ var inject_macro = function() {
 };
 
 
-describe('nunja.stock.molds/model inner model async macro', function() {
+describe_('nunja.stock.molds/model inner model async macro', function() {
 
     before(function() {
         this.engine = core.engine;


### PR DESCRIPTION
Working towards the support the intended usage of the uritemplates with actual path fragments, but this need a version of the `uritemplate` library with the updated fixes.

Also this includes a renewed attempt to include support for building with `webpack`.  This however need some new features that were introduced to the `nunja` package that has not been released yet.

Various version bumps to the CI matrix is done, along with updated installation instructions for this package.